### PR TITLE
Added python format to the file dialogues

### DIFF
--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -691,7 +691,7 @@ bool TabManager::saveAs(EditorInterface *edt)
   assert(edt != nullptr);
 
   const auto dir = edt->filepath.isEmpty() ? _("Untitled.scad") : edt->filepath;
-  auto filename = QFileDialog::getSaveFileName(par, _("Save File"), dir, _("OpenSCAD Designs (*.scad)"));
+  auto filename = QFileDialog::getSaveFileName(par, _("Save File"), dir, QString(_("OpenSCAD Designs (*.scad *.csg)"))+";;"+QString(_("Python OpenSCAD Designs (*.py)")));
   if (filename.isEmpty()) {
     return false;
   }
@@ -722,7 +722,7 @@ bool TabManager::saveACopy(EditorInterface *edt)
   assert(edt != nullptr);
 
   const auto dir = edt->filepath.isEmpty() ? _("Untitled.scad") : edt->filepath;
-  auto filename = QFileDialog::getSaveFileName(par, _("Save a Copy"), dir, _("OpenSCAD Designs (*.scad)"));
+  auto filename = QFileDialog::getSaveFileName(par, _("Save a Copy"), dir, QString(_("OpenSCAD Designs (*.scad *.csg)"))+";;"+QString(_("Python OpenSCAD Designs (*.py)")));
   if (filename.isEmpty()) {
     return false;
   }

--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -43,7 +43,7 @@ QFileInfo UIUtils::openFile(QWidget *parent)
   QSettingsCached settings;
   QString last_dirname = settings.value("lastOpenDirName").toString();
   QString new_filename = QFileDialog::getOpenFileName(parent, "Open File",
-                                                      last_dirname, "OpenSCAD Designs (*.scad *.csg)");
+                                                      last_dirname, "OpenSCAD Designs (*.scad *.csg);;Python OpenSCAD Designs (*.py)");
 
   if (new_filename.isEmpty()) {
     return {};
@@ -61,7 +61,7 @@ QFileInfoList UIUtils::openFiles(QWidget *parent)
   QSettingsCached settings;
   QString last_dirname = settings.value("lastOpenDirName").toString();
   QStringList new_filenames = QFileDialog::getOpenFileNames(parent, "Open File",
-                                                            last_dirname, "OpenSCAD Designs (*.scad *.csg)");
+                                                            last_dirname, "OpenSCAD Designs (*.scad *.csg);;Python OpenSCAD Designs (*.py)");
 
   QFileInfoList fileInfoList;
   for (const QString& filename: new_filenames) {


### PR DESCRIPTION
Pretty simple change, simply adds adds a "Python OpenSCAD Designs" option with the *.py) extension for file prompts.
This still needs a bit of cleanup before merging!