### PR TITLE
Ensure proper extension is used in file save 

### DIFF
--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -691,13 +691,21 @@ bool TabManager::saveAs(EditorInterface *edt)
   assert(edt != nullptr);
 
   const auto dir = edt->filepath.isEmpty() ? _("Untitled.scad") : edt->filepath;
-  auto filename = QFileDialog::getSaveFileName(par, _("Save File"), dir, QString("%1;;%2").arg(_("OpenSCAD Designs (*.scad *.csg)"), _("Python OpenSCAD Designs (*.py)")));
+  QString selectedFilter;
+  QString pythonFilter = _("Python OpenSCAD Designs (*.py)");
+  auto filename = QFileDialog::getSaveFileName(par, _("Save File"), dir, QString("%1;;%2").arg(_("OpenSCAD Designs (*.scad *.csg)"), pythonFilter), &selectedFilter);
   if (filename.isEmpty()) {
     return false;
   }
 
   if (QFileInfo(filename).suffix().isEmpty()) {
-    filename.append(".scad");
+    // Check if the user selected the Python filter
+    if (selectedFilter == pythonFilter) {
+        filename.append(".py");
+    } else {
+        // For other cases, use .scad as the default extension
+        filename.append(".scad");
+    }
 
     // Manual overwrite check since Qt doesn't do it, when using the
     // defaultSuffix property
@@ -722,13 +730,19 @@ bool TabManager::saveACopy(EditorInterface *edt)
   assert(edt != nullptr);
 
   const auto dir = edt->filepath.isEmpty() ? _("Untitled.scad") : edt->filepath;
-  auto filename = QFileDialog::getSaveFileName(par, _("Save a Copy"), dir, QString("%1;;%2").arg(_("OpenSCAD Designs (*.scad *.csg)"), _("Python OpenSCAD Designs (*.py)")));
+  QString selectedFilter;
+  QString pythonFilter = _("Python OpenSCAD Designs (*.py)");
+  auto filename = QFileDialog::getSaveFileName(par, _("Save a Copy"), dir, QString("%1;;%2").arg(_("OpenSCAD Designs (*.scad *.csg)"), pythonFilter), &selectedFilter);
   if (filename.isEmpty()) {
     return false;
   }
 
   if (QFileInfo(filename).suffix().isEmpty()) {
-    filename.append(".scad");
+      if (selectedFilter == pythonFilter) {
+          filename.append(".py");
+      } else {
+          filename.append(".scad");
+      }
   }
 
   return save(edt, filename);

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -691,7 +691,7 @@ bool TabManager::saveAs(EditorInterface *edt)
   assert(edt != nullptr);
 
   const auto dir = edt->filepath.isEmpty() ? _("Untitled.scad") : edt->filepath;
-  auto filename = QFileDialog::getSaveFileName(par, _("Save File"), dir, QString(_("OpenSCAD Designs (*.scad *.csg)"))+";;"+QString(_("Python OpenSCAD Designs (*.py)")));
+  auto filename = QFileDialog::getSaveFileName(par, _("Save File"), dir, QString("%1;;%2").arg(_("OpenSCAD Designs (*.scad *.csg)"), _("Python OpenSCAD Designs (*.py)")));
   if (filename.isEmpty()) {
     return false;
   }
@@ -722,7 +722,7 @@ bool TabManager::saveACopy(EditorInterface *edt)
   assert(edt != nullptr);
 
   const auto dir = edt->filepath.isEmpty() ? _("Untitled.scad") : edt->filepath;
-  auto filename = QFileDialog::getSaveFileName(par, _("Save a Copy"), dir, QString(_("OpenSCAD Designs (*.scad *.csg)"))+";;"+QString(_("Python OpenSCAD Designs (*.py)")));
+  auto filename = QFileDialog::getSaveFileName(par, _("Save a Copy"), dir, QString("%1;;%2").arg(_("OpenSCAD Designs (*.scad *.csg)"), _("Python OpenSCAD Designs (*.py)")));
   if (filename.isEmpty()) {
     return false;
   }

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -703,6 +703,7 @@ bool TabManager::saveAs(EditorInterface *edt)
   }
 
   if (QFileInfo(filename).suffix().isEmpty()) {
+#ifdef ENABLE_PYTHON
     // Check if the user selected the Python filter
     if (selectedFilter == pythonFilter) {
         filename.append(".py");
@@ -710,6 +711,9 @@ bool TabManager::saveAs(EditorInterface *edt)
         // For other cases, use .scad as the default extension
         filename.append(".scad");
     }
+#else
+    filename.append(".scad");
+#endif
 
     // Manual overwrite check since Qt doesn't do it, when using the
     // defaultSuffix property
@@ -735,7 +739,9 @@ bool TabManager::saveACopy(EditorInterface *edt)
 
   const auto dir = edt->filepath.isEmpty() ? _("Untitled.scad") : edt->filepath;
 #ifdef ENABLE_PYTHON
-  auto filename = QFileDialog::getSaveFileName(par, _("Save a Copy"), dir, QString(_("OpenSCAD Designs (*.scad *.csg)"))+";;"+QString(_("Python OpenSCAD Designs (*.py)")));
+  QString selectedFilter;
+  QString pythonFilter = _("Python OpenSCAD Designs (*.py)");
+  auto filename = QFileDialog::getSaveFileName(par, _("Save File"), dir, QString("%1;;%2").arg(_("OpenSCAD Designs (*.scad *.csg)"), pythonFilter), &selectedFilter);
 #else
   auto filename = QFileDialog::getSaveFileName(par, _("Save a Copy"), dir, _("OpenSCAD Designs (*.scad)"));
 #endif
@@ -744,11 +750,17 @@ bool TabManager::saveACopy(EditorInterface *edt)
   }
 
   if (QFileInfo(filename).suffix().isEmpty()) {
-      if (selectedFilter == pythonFilter) {
-          filename.append(".py");
-      } else {
-          filename.append(".scad");
-      }
+    #ifdef ENABLE_PYTHON
+    // Check if the user selected the Python filter
+    if (selectedFilter == pythonFilter) {
+        filename.append(".py");
+    } else {
+        // For other cases, use .scad as the default extension
+        filename.append(".scad");
+    }
+    #else
+    filename.append(".scad");
+    #endif
   }
 
   return save(edt, filename);

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -691,7 +691,7 @@ bool TabManager::saveAs(EditorInterface *edt)
   assert(edt != nullptr);
 
   const auto dir = edt->filepath.isEmpty() ? _("Untitled.scad") : edt->filepath;
-  auto filename = QFileDialog::getSaveFileName(par, _("Save File"), dir, _("OpenSCAD Designs (*.scad)"));
+  auto filename = QFileDialog::getSaveFileName(par, _("Save File"), dir, QString(_("OpenSCAD Designs (*.scad *.csg)"))+";;"+QString(_("Python OpenSCAD Designs (*.py)")));
   if (filename.isEmpty()) {
     return false;
   }
@@ -722,7 +722,7 @@ bool TabManager::saveACopy(EditorInterface *edt)
   assert(edt != nullptr);
 
   const auto dir = edt->filepath.isEmpty() ? _("Untitled.scad") : edt->filepath;
-  auto filename = QFileDialog::getSaveFileName(par, _("Save a Copy"), dir, _("OpenSCAD Designs (*.scad)"));
+  auto filename = QFileDialog::getSaveFileName(par, _("Save a Copy"), dir, QString(_("OpenSCAD Designs (*.scad *.csg)"))+";;"+QString(_("Python OpenSCAD Designs (*.py)")));
   if (filename.isEmpty()) {
     return false;
   }

--- a/src/gui/UIUtils.cc
+++ b/src/gui/UIUtils.cc
@@ -43,7 +43,7 @@ QFileInfo UIUtils::openFile(QWidget *parent)
   QSettingsCached settings;
   QString last_dirname = settings.value("lastOpenDirName").toString();
   QString new_filename = QFileDialog::getOpenFileName(parent, "Open File",
-                                                      last_dirname, "OpenSCAD Designs (*.scad *.csg)");
+                                                      last_dirname, "OpenSCAD Designs (*.scad *.csg);;Python OpenSCAD Designs (*.py)");
 
   if (new_filename.isEmpty()) {
     return {};
@@ -61,7 +61,7 @@ QFileInfoList UIUtils::openFiles(QWidget *parent)
   QSettingsCached settings;
   QString last_dirname = settings.value("lastOpenDirName").toString();
   QStringList new_filenames = QFileDialog::getOpenFileNames(parent, "Open File",
-                                                            last_dirname, "OpenSCAD Designs (*.scad *.csg)");
+                                                            last_dirname, "OpenSCAD Designs (*.scad *.csg);;Python OpenSCAD Designs (*.py)");
 
   QFileInfoList fileInfoList;
   for (const QString& filename: new_filenames) {


### PR DESCRIPTION
This was meant to be included in #2 , but i didn't push before it got merged, and you can't re-open a merged PR.
I'm merging to `python-pr3` since this is a direct follow-up, but my next pull requests will be to the `python` branch.

Anyways, this makes sure that the right extension is added to the filename no extension is provided. Before, it always defaulted to getSaveFileName.