### PR TITLE
Improve commenting logic

### DIFF
--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -117,7 +117,7 @@ const boost::property_tree::ptree& EditorColorScheme::propertyTree() const
   return pt;
 }
 
-ScintillaEditor::ScintillaEditor(QWidget *parent) : EditorInterface(parent)
+ScintillaEditor::ScintillaEditor(QWidget *parent, MainWindow &mainWindow) : EditorInterface(parent), mainWindow(mainWindow)
 {
   api = nullptr;
   lexer = nullptr;
@@ -873,12 +873,18 @@ void ScintillaEditor::unindentSelection()
 
 void ScintillaEditor::commentSelection()
 {
+  auto commentString = "//";
+  #ifdef ENABLE_PYTHON
+  if (mainWindow.python_active) {
+    commentString = "#";
+  }
+  #endif
   auto hasSelection = qsci->hasSelectedText();
 
   int lineFrom, lineTo;
   getRange(&lineFrom, &lineTo);
   for (int line = lineFrom; line <= lineTo; ++line) {
-    qsci->insertAt("//", line, 0);
+    qsci->insertAt(commentString, line, 0);
   }
 
   if (hasSelection) {
@@ -888,13 +894,19 @@ void ScintillaEditor::commentSelection()
 
 void ScintillaEditor::uncommentSelection()
 {
+  auto commentString = "//";
+  #ifdef ENABLE_PYTHON
+  if (mainWindow.python_active) {
+    commentString = "#";
+  }
+  #endif
   auto hasSelection = qsci->hasSelectedText();
 
   int lineFrom, lineTo;
   getRange(&lineFrom, &lineTo);
   for (int line = lineFrom; line <= lineTo; ++line) {
     QString lineText = qsci->text(line);
-    if (lineText.startsWith("//")) {
+    if (lineText.startsWith(commentString)) {
       qsci->setSelection(line, 0, line, 2);
       qsci->removeSelectedText();
     }

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -874,7 +874,7 @@ void ScintillaEditor::unindentSelection()
 void ScintillaEditor::commentSelection()
 {
   #ifdef ENABLE_PYTHON
-  const auto commentString = mainWindow.python_active ? "#" : "//";
+  const auto commentString = mainWindow.python_active ? "# " : "//";
   #else
   const auto commentString = "//";
   #endif
@@ -894,7 +894,7 @@ void ScintillaEditor::commentSelection()
 void ScintillaEditor::uncommentSelection()
 {
   #ifdef ENABLE_PYTHON
-  const auto commentString = mainWindow.python_active ? "#" : "//";
+  const auto commentString = mainWindow.python_active ? "# " : "//";
   #else
   const auto commentString = "//";
   #endif

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -873,11 +873,10 @@ void ScintillaEditor::unindentSelection()
 
 void ScintillaEditor::commentSelection()
 {
-  auto commentString = "//";
   #ifdef ENABLE_PYTHON
-  if (mainWindow.python_active) {
-    commentString = "#";
-  }
+  const auto commentString = mainWindow.python_active ? "#" : "//";
+  #else
+  const auto commentString = "//";
   #endif
   auto hasSelection = qsci->hasSelectedText();
 
@@ -894,11 +893,10 @@ void ScintillaEditor::commentSelection()
 
 void ScintillaEditor::uncommentSelection()
 {
-  auto commentString = "//";
   #ifdef ENABLE_PYTHON
-  if (mainWindow.python_active) {
-    commentString = "#";
-  }
+  const auto commentString = mainWindow.python_active ? "#" : "//";
+  #else
+  const auto commentString = "//";
   #endif
   auto hasSelection = qsci->hasSelectedText();
 

--- a/src/gui/ScintillaEditor.cc
+++ b/src/gui/ScintillaEditor.cc
@@ -908,6 +908,11 @@ void ScintillaEditor::uncommentSelection()
       qsci->setSelection(line, 0, line, 2);
       qsci->removeSelectedText();
     }
+    // Handles the case where there's a comment without space
+    else if (commentString == "# " && lineText.startsWith("#")) {
+      qsci->setSelection(line, 0, line, 1);
+      qsci->removeSelectedText();
+    }
   }
   if (hasSelection) {
     qsci->setSelection(lineFrom, 0, lineTo, std::max(0, qsci->lineLength(lineTo) - 1));

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -15,6 +15,7 @@
 #include "Editor.h"
 #include "memory.h"
 #include "ScadApi.h"
+#include "MainWindow.h"
 
 // don't need the full definition, because it confuses Qt
 class ScadLexer;
@@ -49,7 +50,7 @@ class ScintillaEditor : public EditorInterface
   using colorscheme_set_t = std::multimap<int, shared_ptr<EditorColorScheme>, std::less<>>;
 
 public:
-  ScintillaEditor(QWidget *parent);
+  ScintillaEditor(QWidget *parent, MainWindow &mainWindow);
   QsciScintilla *qsci;
   QString toPlainText() override;
   void initMargin();
@@ -172,4 +173,5 @@ private:
   QStringList userList;
   QMap<QString, ScadTemplate> templateMap;
   static const QString cursorPlaceHolder;
+  MainWindow &mainWindow;
 };

--- a/src/gui/ScintillaEditor.h
+++ b/src/gui/ScintillaEditor.h
@@ -13,9 +13,9 @@
 #include <Qsci/qsciscintilla.h>
 
 #include "Editor.h"
+#include "MainWindow.h"
 #include "memory.h"
 #include "ScadApi.h"
-#include "MainWindow.h"
 
 // don't need the full definition, because it confuses Qt
 class ScadLexer;

--- a/src/gui/TabManager.cc
+++ b/src/gui/TabManager.cc
@@ -164,7 +164,7 @@ void TabManager::createTab(const QString& filename)
 {
   assert(par != nullptr);
 
-  editor = new ScintillaEditor(tabWidget);
+  editor = new ScintillaEditor(tabWidget, *par);
   par->activeEditor = editor;
   editor->parameterWidget = new ParameterWidget(par->parameterDock);
   connect(editor->parameterWidget, SIGNAL(parametersChanged()), par, SLOT(actionRenderPreview()));


### PR DESCRIPTION
This makes comments respect [PEP8](https://peps.python.org/pep-0008/) by adding a single space after the #
It also optimizes the previous comment changes