### PR TITLE
Build fix: specify more path to node.h

### DIFF
--- a/src/geometry/manifold/manifold-applyops.cc
+++ b/src/geometry/manifold/manifold-applyops.cc
@@ -5,7 +5,7 @@
 
 #include "manifoldutils.h"
 #include "ManifoldGeometry.h"
-#include "node.h"
+#include "src/core/node.h"
 #include "progress.h"
 #include "printutils.h"
 


### PR DESCRIPTION
Building on Ubuntu with Python 3.8, there is a /usr/include/python3.8/node.h, which was being included before ./src/core/node.h.  

Resolved the conflict by specifying a complete relative path in manifold-applyops.cc, which appears to be the only place node.h is referenced.